### PR TITLE
feat(profile): Add circular avatar with photo or initial

### DIFF
--- a/source/repos/Ora/app/src/main/java/com/ora/wellbeing/presentation/components/UserAvatar.kt
+++ b/source/repos/Ora/app/src/main/java/com/ora/wellbeing/presentation/components/UserAvatar.kt
@@ -1,0 +1,72 @@
+package com.ora.wellbeing.presentation.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+
+/**
+ * Avatar circulaire de l'utilisateur avec photo ou initiale
+ * - Si photoUrl est fournie : affiche l'image
+ * - Sinon : affiche un cercle coloré avec la première lettre du firstName
+ *
+ * @param firstName Prénom de l'utilisateur (pour l'initiale)
+ * @param photoUrl URL de la photo de profil (optionnel)
+ * @param size Taille du cercle en Dp
+ * @param fontSize Taille du texte pour l'initiale
+ * @param backgroundColor Couleur de fond du cercle (par défaut: tertiary)
+ */
+@Composable
+fun UserAvatar(
+    firstName: String,
+    photoUrl: String? = null,
+    size: Dp = 140.dp,
+    fontSize: TextUnit = 60.sp,
+    backgroundColor: Color = MaterialTheme.colorScheme.tertiary,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .size(size)
+            .clip(CircleShape)
+            .background(backgroundColor),
+        contentAlignment = Alignment.Center
+    ) {
+        if (!photoUrl.isNullOrBlank()) {
+            // Afficher la photo si disponible
+            AsyncImage(
+                model = photoUrl,
+                contentDescription = "Photo de profil",
+                modifier = Modifier
+                    .size(size)
+                    .clip(CircleShape),
+                contentScale = ContentScale.Crop
+            )
+        } else {
+            // Afficher l'initiale si pas de photo
+            val initial = firstName.firstOrNull()?.uppercase() ?: "?"
+            Text(
+                text = initial,
+                style = MaterialTheme.typography.displayLarge.copy(
+                    color = Color.White,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = fontSize
+                )
+            )
+        }
+    }
+}

--- a/source/repos/Ora/app/src/main/java/com/ora/wellbeing/presentation/screens/profile/ProfileScreen.kt
+++ b/source/repos/Ora/app/src/main/java/com/ora/wellbeing/presentation/screens/profile/ProfileScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ora.wellbeing.presentation.theme.*
+import com.ora.wellbeing.presentation.components.UserAvatar
 
 // FIX(user-dynamic): ProfileScreen mis à jour pour afficher les données Firestore
 @Composable
@@ -228,31 +229,20 @@ private fun ProfileHeader(
 }
 
 // FIX(user-dynamic): Afficher "Invité" si firstName/name est vide
+// FIX(avatar): Utilise UserAvatar avec photo ou initiale
 @Composable
 private fun ProfileUserInfo(profile: UserProfile) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier.fillMaxWidth()
     ) {
-        // Photo de profil circulaire (grande)
-        Box(
-            modifier = Modifier
-                .size(140.dp)
-                .clip(CircleShape)
-                .background(MaterialTheme.colorScheme.tertiary),
-            contentAlignment = Alignment.Center
-        ) {
-            // TODO: Remplacer par AsyncImage quand l'URL sera disponible
-            val displayName = profile.name.ifBlank { "Invité" }
-            Text(
-                text = displayName.first().toString().uppercase(),
-                style = MaterialTheme.typography.displayLarge.copy(
-                    color = Color.White,
-                    fontWeight = FontWeight.Bold,
-                    fontSize = 60.sp
-                )
-            )
-        }
+        // Avatar circulaire avec photo ou initiale du prénom
+        UserAvatar(
+            firstName = profile.firstName.ifBlank { profile.name.ifBlank { "Invité" } },
+            photoUrl = profile.photoUrl,
+            size = 140.dp,
+            fontSize = 60.sp
+        )
 
         Spacer(modifier = Modifier.height(16.dp))
 

--- a/source/repos/Ora/app/src/main/java/com/ora/wellbeing/presentation/screens/profile/ProfileUiState.kt
+++ b/source/repos/Ora/app/src/main/java/com/ora/wellbeing/presentation/screens/profile/ProfileUiState.kt
@@ -23,9 +23,11 @@ data class ProfileUiState(
 /**
  * Profil utilisateur simplifié selon mockup
  * FIX(user-dynamic): Ajout de isPremium et planTier
+ * FIX(avatar): Ajout de firstName pour l'avatar circulaire
  */
 data class UserProfile(
     val name: String,
+    val firstName: String = "",
     val motto: String,
     val photoUrl: String? = null,
     val isPremium: Boolean = false, // FIX(user-dynamic): Nouveau champ


### PR DESCRIPTION
## Summary

Ajoute un avatar circulaire réutilisable qui affiche soit la photo de profil de l'utilisateur, soit un cercle coloré avec la première lettre de son prénom.

## Changes

### ✅ Nouveau composable UserAvatar
- **UserAvatar.kt** - Composable réutilisable pour l'avatar utilisateur
- Affiche la photo si `photoUrl` est fournie (via Coil AsyncImage)
- Sinon: cercle coloré (tertiary) avec initiale du `firstName`
- Paramétrable: taille, fontSize, backgroundColor
- Fallback gracieux: "?" si aucun nom disponible

### ✅ Modifications ProfileScreen
- **ProfileUiState.kt** - Ajout du champ `firstName` au modèle `UserProfile`
- **ProfileScreen.kt** - Utilise `UserAvatar` au lieu du Box manuel
- Logique de fallback: `firstName` → `name` → "Invité"

## Files Modified (3 files)

**Nouveau fichier:**
- `presentation/components/UserAvatar.kt` (70 lignes)

**Fichiers modifiés:**
- `presentation/screens/profile/ProfileUiState.kt` (+1 ligne)
- `presentation/screens/profile/ProfileScreen.kt` (-19, +12 lignes)

## Visual Changes

### Avant
```kotlin
// Box manuel avec Text uniquement
Box(...) {
    Text(text = name.first().uppercase())
}
```

### Après
```kotlin
// Composable réutilisable avec support photo
UserAvatar(
    firstName = profile.firstName,
    photoUrl = profile.photoUrl,
    size = 140.dp
)
```

## Build Status

✅ **BUILD SUCCESSFUL in 11s**

## Dependencies

- ✅ Coil 2.5.0 (déjà présent dans le projet)
- Aucune nouvelle dépendance ajoutée

## Test Plan

- [ ] Ouvrir l'écran Profile
- [ ] Vérifier l'avatar circulaire avec initiale
- [ ] Tester avec `firstName` vide → devrait fallback sur `name`
- [ ] Tester avec `photoUrl` fournie → devrait charger l'image
- [ ] Vérifier la couleur de fond (tertiary color)

## Usage Example

```kotlin
// Avatar par défaut (140dp, 60sp)
UserAvatar(
    firstName = "Clara",
    photoUrl = "https://...",
)

// Avatar personnalisé
UserAvatar(
    firstName = "John",
    photoUrl = null,
    size = 80.dp,
    fontSize = 32.sp,
    backgroundColor = Color.Blue
)
```

## Benefits

1. **Réutilisable** - Peut être utilisé ailleurs (navbar, mini-profil, etc.)
2. **Flexible** - Support photo + fallback initiale
3. **Performant** - Coil gère le cache et le chargement async
4. **Design cohérent** - Même style que ProfileEditScreen

## Related

Compatible avec la feature profile-editing (PR #3) qui permet d'uploader une photo de profil.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)