### PR TITLE
feat(i18n): Complete onboarding internationalization with merged info screens

### DIFF
--- a/source/repos/Ora/app/src/main/java/com/ora/wellbeing/data/model/onboarding/InformationScreen.kt
+++ b/source/repos/Ora/app/src/main/java/com/ora/wellbeing/data/model/onboarding/InformationScreen.kt
@@ -1,6 +1,67 @@
 package com.ora.wellbeing.data.model.onboarding
 
 import com.google.firebase.firestore.IgnoreExtraProperties
+import com.ora.wellbeing.core.localization.LocalizationProvider
+
+/**
+ * Information Screen Feature
+ * Represents a feature displayed in an information screen
+ */
+@IgnoreExtraProperties
+class InformationScreenFeature {
+    var icon: String? = null
+    var title: String = ""
+    var titleFr: String = ""
+    var titleEn: String = ""
+    var titleEs: String = ""
+    var description: String = ""
+    var descriptionFr: String = ""
+    var descriptionEn: String = ""
+    var descriptionEs: String = ""
+    var order: Int = 0
+
+    constructor()
+
+    constructor(
+        icon: String?,
+        title: String,
+        titleFr: String,
+        titleEn: String,
+        titleEs: String,
+        description: String,
+        descriptionFr: String,
+        descriptionEn: String,
+        descriptionEs: String,
+        order: Int
+    ) {
+        this.icon = icon
+        this.title = title
+        this.titleFr = titleFr
+        this.titleEn = titleEn
+        this.titleEs = titleEs
+        this.description = description
+        this.descriptionFr = descriptionFr
+        this.descriptionEn = descriptionEn
+        this.descriptionEs = descriptionEs
+        this.order = order
+    }
+
+    fun getLocalizedTitle(locale: String = LocalizationProvider.DEFAULT_LOCALE): String {
+        return when (locale.lowercase()) {
+            "en" -> titleEn.ifBlank { title }
+            "es" -> titleEs.ifBlank { titleEn.ifBlank { title } }
+            else -> titleFr.ifBlank { title }
+        }
+    }
+
+    fun getLocalizedDescription(locale: String = LocalizationProvider.DEFAULT_LOCALE): String {
+        return when (locale.lowercase()) {
+            "en" -> descriptionEn.ifBlank { description }
+            "es" -> descriptionEs.ifBlank { descriptionEn.ifBlank { description } }
+            else -> descriptionFr.ifBlank { description }
+        }
+    }
+}
 
 /**
  * Information Screen Model
@@ -14,19 +75,25 @@ class InformationScreen {
     var title: String = ""
     var titleFr: String = ""
     var titleEn: String = ""
+    var titleEs: String = ""
     var subtitle: String = ""
     var subtitleFr: String = ""
     var subtitleEn: String = ""
+    var subtitleEs: String = ""
     var content: String = ""
     var contentFr: String = ""
     var contentEn: String = ""
+    var contentEs: String = ""
     var bulletPoints: List<String> = emptyList()
     var bulletPointsFr: List<String> = emptyList()
     var bulletPointsEn: List<String> = emptyList()
+    var bulletPointsEs: List<String> = emptyList()
     var ctaText: String = ""
     var ctaTextFr: String = ""
     var ctaTextEn: String = ""
+    var ctaTextEs: String = ""
     var backgroundColor: String = "#F5EFE6"
+    var features: List<InformationScreenFeature> = emptyList()
 
     constructor()
 
@@ -36,18 +103,23 @@ class InformationScreen {
         title: String,
         titleFr: String,
         titleEn: String,
+        titleEs: String,
         subtitle: String,
         subtitleFr: String,
         subtitleEn: String,
+        subtitleEs: String,
         content: String,
         contentFr: String,
         contentEn: String,
+        contentEs: String,
         bulletPoints: List<String>,
         bulletPointsFr: List<String>,
         bulletPointsEn: List<String>,
+        bulletPointsEs: List<String>,
         ctaText: String,
         ctaTextFr: String,
         ctaTextEn: String,
+        ctaTextEs: String,
         backgroundColor: String
     ) {
         this.position = position
@@ -55,27 +127,33 @@ class InformationScreen {
         this.title = title
         this.titleFr = titleFr
         this.titleEn = titleEn
+        this.titleEs = titleEs
         this.subtitle = subtitle
         this.subtitleFr = subtitleFr
         this.subtitleEn = subtitleEn
+        this.subtitleEs = subtitleEs
         this.content = content
         this.contentFr = contentFr
         this.contentEn = contentEn
+        this.contentEs = contentEs
         this.bulletPoints = bulletPoints
         this.bulletPointsFr = bulletPointsFr
         this.bulletPointsEn = bulletPointsEn
+        this.bulletPointsEs = bulletPointsEs
         this.ctaText = ctaText
         this.ctaTextFr = ctaTextFr
         this.ctaTextEn = ctaTextEn
+        this.ctaTextEs = ctaTextEs
         this.backgroundColor = backgroundColor
     }
 
     /**
      * Get localized title based on current locale
      */
-    fun getLocalizedTitle(locale: String = "fr"): String {
-        return when (locale) {
+    fun getLocalizedTitle(locale: String = LocalizationProvider.DEFAULT_LOCALE): String {
+        return when (locale.lowercase()) {
             "en" -> titleEn.ifBlank { title }
+            "es" -> titleEs.ifBlank { titleEn.ifBlank { title } }
             else -> titleFr.ifBlank { title }
         }
     }
@@ -83,9 +161,10 @@ class InformationScreen {
     /**
      * Get localized subtitle based on current locale
      */
-    fun getLocalizedSubtitle(locale: String = "fr"): String {
-        return when (locale) {
+    fun getLocalizedSubtitle(locale: String = LocalizationProvider.DEFAULT_LOCALE): String {
+        return when (locale.lowercase()) {
             "en" -> subtitleEn.ifBlank { subtitle }
+            "es" -> subtitleEs.ifBlank { subtitleEn.ifBlank { subtitle } }
             else -> subtitleFr.ifBlank { subtitle }
         }
     }
@@ -93,9 +172,10 @@ class InformationScreen {
     /**
      * Get localized content based on current locale
      */
-    fun getLocalizedContent(locale: String = "fr"): String {
-        return when (locale) {
+    fun getLocalizedContent(locale: String = LocalizationProvider.DEFAULT_LOCALE): String {
+        return when (locale.lowercase()) {
             "en" -> contentEn.ifBlank { content }
+            "es" -> contentEs.ifBlank { contentEn.ifBlank { content } }
             else -> contentFr.ifBlank { content }
         }
     }
@@ -103,9 +183,10 @@ class InformationScreen {
     /**
      * Get localized bullet points based on current locale
      */
-    fun getLocalizedBulletPoints(locale: String = "fr"): List<String> {
-        return when (locale) {
+    fun getLocalizedBulletPoints(locale: String = LocalizationProvider.DEFAULT_LOCALE): List<String> {
+        return when (locale.lowercase()) {
             "en" -> bulletPointsEn.ifEmpty { bulletPoints }
+            "es" -> bulletPointsEs.ifEmpty { bulletPointsEn.ifEmpty { bulletPoints } }
             else -> bulletPointsFr.ifEmpty { bulletPoints }
         }
     }
@@ -113,9 +194,10 @@ class InformationScreen {
     /**
      * Get localized CTA text based on current locale
      */
-    fun getLocalizedCtaText(locale: String = "fr"): String {
-        return when (locale) {
+    fun getLocalizedCtaText(locale: String = LocalizationProvider.DEFAULT_LOCALE): String {
+        return when (locale.lowercase()) {
             "en" -> ctaTextEn.ifBlank { ctaText }
+            "es" -> ctaTextEs.ifBlank { ctaTextEn.ifBlank { ctaText } }
             else -> ctaTextFr.ifBlank { ctaText }
         }
     }

--- a/source/repos/Ora/app/src/main/java/com/ora/wellbeing/data/model/onboarding/ProfileField.kt
+++ b/source/repos/Ora/app/src/main/java/com/ora/wellbeing/data/model/onboarding/ProfileField.kt
@@ -18,8 +18,12 @@ class ProfileField {
     var label: String = ""
     var labelFr: String = ""
     var labelEn: String = ""
+    var labelEs: String = ""
     var inputType: String = "text"
     var placeholder: String? = null
+    var placeholderFr: String? = null
+    var placeholderEn: String? = null
+    var placeholderEs: String? = null
     var maxLength: Int? = null
     var required: Boolean = false
     var order: Int = 0
@@ -32,8 +36,12 @@ class ProfileField {
         label: String,
         labelFr: String,
         labelEn: String,
+        labelEs: String,
         inputType: String,
         placeholder: String? = null,
+        placeholderFr: String? = null,
+        placeholderEn: String? = null,
+        placeholderEs: String? = null,
         maxLength: Int? = null,
         required: Boolean = false,
         order: Int = 0,
@@ -43,8 +51,12 @@ class ProfileField {
         this.label = label
         this.labelFr = labelFr
         this.labelEn = labelEn
+        this.labelEs = labelEs
         this.inputType = inputType
         this.placeholder = placeholder
+        this.placeholderFr = placeholderFr
+        this.placeholderEn = placeholderEn
+        this.placeholderEs = placeholderEs
         this.maxLength = maxLength
         this.required = required
         this.order = order
@@ -59,6 +71,22 @@ class ProfileField {
             else -> ProfileFieldInputType.TEXT
         }
     }
+
+    fun getLocalizedLabel(locale: String = "fr"): String {
+        return when (locale.lowercase()) {
+            "en" -> labelEn.takeIf { it.isNotBlank() } ?: label
+            "es" -> labelEs.takeIf { it.isNotBlank() } ?: labelEn.takeIf { it.isNotBlank() } ?: label
+            else -> labelFr.takeIf { it.isNotBlank() } ?: label
+        }
+    }
+
+    fun getLocalizedPlaceholder(locale: String = "fr"): String? {
+        return when (locale.lowercase()) {
+            "en" -> placeholderEn?.takeIf { it.isNotBlank() } ?: placeholder
+            "es" -> placeholderEs?.takeIf { it.isNotBlank() } ?: placeholderEn?.takeIf { it.isNotBlank() } ?: placeholder
+            else -> placeholderFr?.takeIf { it.isNotBlank() } ?: placeholder
+        }
+    }
 }
 
 @IgnoreExtraProperties
@@ -67,6 +95,7 @@ class ProfileFieldOption {
     var label: String = ""
     var labelFr: String = ""
     var labelEn: String = ""
+    var labelEs: String = ""
     var icon: String? = null
     var order: Int = 0
 
@@ -77,6 +106,7 @@ class ProfileFieldOption {
         label: String,
         labelFr: String,
         labelEn: String,
+        labelEs: String,
         icon: String? = null,
         order: Int = 0
     ) {
@@ -84,7 +114,16 @@ class ProfileFieldOption {
         this.label = label
         this.labelFr = labelFr
         this.labelEn = labelEn
+        this.labelEs = labelEs
         this.icon = icon
         this.order = order
+    }
+
+    fun getLocalizedLabel(locale: String = "fr"): String {
+        return when (locale.lowercase()) {
+            "en" -> labelEn.takeIf { it.isNotBlank() } ?: label
+            "es" -> labelEs.takeIf { it.isNotBlank() } ?: labelEn.takeIf { it.isNotBlank() } ?: label
+            else -> labelFr.takeIf { it.isNotBlank() } ?: label
+        }
     }
 }

--- a/source/repos/Ora/app/src/main/java/com/ora/wellbeing/data/model/onboarding/QuestionType.kt
+++ b/source/repos/Ora/app/src/main/java/com/ora/wellbeing/data/model/onboarding/QuestionType.kt
@@ -54,12 +54,16 @@ class QuestionTypeConfig {
     var content: String? = null
     var contentFr: String? = null
     var contentEn: String? = null
+    var contentEs: String? = null
     var bulletPoints: List<String>? = null
     var bulletPointsFr: List<String>? = null
     var bulletPointsEn: List<String>? = null
+    var bulletPointsEs: List<String>? = null
+    var features: List<InformationScreenFeature>? = null
     var ctaText: String? = null
     var ctaTextFr: String? = null
     var ctaTextEn: String? = null
+    var ctaTextEs: String? = null
     var backgroundColor: String? = null
 
     constructor()

--- a/source/repos/Ora/app/src/main/java/com/ora/wellbeing/presentation/screens/onboarding/OnboardingScreen.kt
+++ b/source/repos/Ora/app/src/main/java/com/ora/wellbeing/presentation/screens/onboarding/OnboardingScreen.kt
@@ -437,6 +437,7 @@ fun OnboardingQuestionCard(
 
                 ProfileGroupContent(
                     question = question,
+                    currentLocale = currentLocale,
                     profileData = profileData,
                     onProfileDataChange = { newData ->
                         profileData = newData
@@ -1151,13 +1152,15 @@ fun InformationScreenContent(
     }
 
     // Get localized content from question type config
-    val content = when (currentLocale) {
+    val content = when (currentLocale.lowercase()) {
         "en" -> question.type.contentEn ?: question.type.content
+        "es" -> question.type.contentEs ?: question.type.contentEn ?: question.type.content
         else -> question.type.contentFr ?: question.type.content
     } ?: ""
 
-    val bulletPoints = when (currentLocale) {
+    val bulletPoints = when (currentLocale.lowercase()) {
         "en" -> question.type.bulletPointsEn ?: question.type.bulletPoints
+        "es" -> question.type.bulletPointsEs ?: question.type.bulletPointsEn ?: question.type.bulletPoints
         else -> question.type.bulletPointsFr ?: question.type.bulletPoints
     } ?: emptyList()
 
@@ -1209,8 +1212,54 @@ fun InformationScreenContent(
             )
         }
 
-        // Bullet points
-        if (bulletPoints.isNotEmpty()) {
+        // Features or Bullet points
+        val features = question.type.features
+        if (features != null && features.isNotEmpty()) {
+            // Display features with icons and descriptions
+            Spacer(modifier = Modifier.height(16.dp))
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                features.sortedBy { it.order }.forEach { feature ->
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        verticalAlignment = Alignment.Top
+                    ) {
+                        // Icon
+                        feature.icon?.let { emoji ->
+                            Text(
+                                text = emoji,
+                                style = MaterialTheme.typography.titleLarge,
+                                fontSize = 24.sp
+                            )
+                        }
+
+                        // Title and description
+                        Column(
+                            modifier = Modifier.weight(1f),
+                            verticalArrangement = Arrangement.spacedBy(4.dp)
+                        ) {
+                            Text(
+                                text = feature.getLocalizedTitle(currentLocale),
+                                style = MaterialTheme.typography.titleSmall,
+                                fontWeight = androidx.compose.ui.text.font.FontWeight.SemiBold,
+                                color = MaterialTheme.colorScheme.onBackground
+                            )
+                            Text(
+                                text = feature.getLocalizedDescription(currentLocale),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.8f)
+                            )
+                        }
+                    }
+                }
+            }
+        } else if (bulletPoints.isNotEmpty()) {
+            // Fallback to bullet points if no features
             Spacer(modifier = Modifier.height(8.dp))
             Column(
                 modifier = Modifier
@@ -1288,6 +1337,7 @@ fun EnhancedTextInput(
 @Composable
 fun ProfileGroupContent(
     question: OnboardingQuestion,
+    currentLocale: String,
     profileData: Map<String, String>,
     onProfileDataChange: (Map<String, String>) -> Unit
 ) {
@@ -1307,8 +1357,8 @@ fun ProfileGroupContent(
                             newData[field.id] = value
                             onProfileDataChange(newData)
                         },
-                        label = { Text(field.label) },
-                        placeholder = field.placeholder?.let { { Text(it) } },
+                        label = { Text(field.getLocalizedLabel(currentLocale)) },
+                        placeholder = field.getLocalizedPlaceholder(currentLocale)?.let { { Text(it) } },
                         modifier = Modifier.fillMaxWidth(),
                         shape = RoundedCornerShape(16.dp),
                         singleLine = true,
@@ -1329,8 +1379,8 @@ fun ProfileGroupContent(
                     OutlinedTextField(
                         value = selectedDate,
                         onValueChange = { }, // Read-only, opens date picker on click
-                        label = { Text(field.label) },
-                        placeholder = field.placeholder?.let { { Text(it) } },
+                        label = { Text(field.getLocalizedLabel(currentLocale)) },
+                        placeholder = field.getLocalizedPlaceholder(currentLocale)?.let { { Text(it) } },
                         modifier = Modifier
                             .fillMaxWidth()
                             .clickable { showDatePicker = true },
@@ -1396,7 +1446,7 @@ fun ProfileGroupContent(
                         verticalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
                         Text(
-                            text = field.label,
+                            text = field.getLocalizedLabel(currentLocale),
                             style = MaterialTheme.typography.titleMedium,
                             color = MaterialTheme.colorScheme.onBackground
                         )
@@ -1443,7 +1493,7 @@ fun ProfileGroupContent(
                                     }
 
                                     Text(
-                                        text = option.label,
+                                        text = option.getLocalizedLabel(currentLocale),
                                         style = MaterialTheme.typography.bodyLarge,
                                         color = if (isSelected) {
                                             MaterialTheme.colorScheme.onPrimaryContainer
@@ -1470,12 +1520,14 @@ fun ProfileGroupContent(
     }
 }
 
+@Composable
 fun getCategoryLabel(category: String): String {
     return when (category.lowercase()) {
-        "goals" -> "🎯 Objectifs"
-        "experience" -> "⭐ Expérience"
-        "preferences" -> "❤️ Préférences"
-        "personalization" -> "✨ Personnalisation"
+        "goals" -> stringResource(R.string.onboarding_category_goals)
+        "experience" -> stringResource(R.string.onboarding_category_experience)
+        "preferences" -> stringResource(R.string.onboarding_category_preferences)
+        "personalization" -> stringResource(R.string.onboarding_category_personalization)
+        "information" -> stringResource(R.string.onboarding_category_information)
         else -> category
     }
 }

--- a/source/repos/Ora/app/src/main/res/values-en/strings.xml
+++ b/source/repos/Ora/app/src/main/res/values-en/strings.xml
@@ -383,6 +383,13 @@
     <string name="massage_pressure_low">Light</string>
     <string name="massage_pressure_medium">Medium</string>
     <string name="massage_pressure_high">Strong</string>
+
+    <!-- Onboarding Categories (NEW - Issue #39 - Phase 1d.2) -->
+    <string name="onboarding_category_goals">🎯 Goals</string>
+    <string name="onboarding_category_experience">⭐ Experience</string>
+    <string name="onboarding_category_preferences">❤️ Preferences</string>
+    <string name="onboarding_category_personalization">✨ Personalization</string>
+    <string name="onboarding_category_information">ℹ️ Information</string>
     <string name="massage_zones_completed">Zones completed: %1$d/%2$d</string>
     <string name="massage_zone_previous">Previous zone</string>
     <string name="massage_zone_next">Next zone</string>
@@ -461,6 +468,11 @@
     <string name="common_next">Next</string>
     <string name="common_finish">Finish</string>
     <string name="common_ok">OK</string>
+    <string name="content_desc_previous">Previous</string>
+    <string name="content_desc_next">Next</string>
+    <string name="content_desc_complete">Complete</string>
+    <string name="content_desc_selected">Selected</string>
+    <string name="content_desc_time">Time</string>
     <string name="common_days_unit">days</string>
     <string name="common_select_date">Select a date</string>
     <string name="common_select">Select</string>
@@ -488,10 +500,6 @@
     <string name="onboarding_character_count">%1$d / %2$d characters</string>
     <string name="onboarding_error_load_config">Unable to load questionnaire</string>
     <string name="onboarding_preparing">Preparing your questionnaire...</string>
-    <string name="onboarding_category_goals">🎯 Goals</string>
-    <string name="onboarding_category_experience">⭐ Experience</string>
-    <string name="onboarding_category_preferences">❤️ Preferences</string>
-    <string name="onboarding_category_personalization">✨ Personalization</string>
     <string name="onboarding_feature_personalized_title">Personalized content</string>
     <string name="onboarding_feature_personalized_desc">Recommendations tailored to your goals</string>
     <string name="onboarding_feature_tracking_title">Progress tracking</string>
@@ -505,6 +513,7 @@
     <string name="error_config_not_loaded">Configuration not loaded</string>
     <string name="error_load_questionnaire">Unable to load questionnaire: %1$s</string>
     <string name="error_save_onboarding">Error saving: %1$s</string>
+    <string name="onboarding_error_load_config_with_reason">Unable to load questionnaire: %1$s</string>
 
     <!-- Home Personalized Section -->
     <string name="home_personalized_description">Based on your goals and preferences</string>

--- a/source/repos/Ora/app/src/main/res/values-es/strings.xml
+++ b/source/repos/Ora/app/src/main/res/values-es/strings.xml
@@ -383,6 +383,13 @@
     <string name="massage_pressure_low">Ligera</string>
     <string name="massage_pressure_medium">Media</string>
     <string name="massage_pressure_high">Fuerte</string>
+
+    <!-- Onboarding Categories (NEW - Issue #39 - Phase 1d.2) -->
+    <string name="onboarding_category_goals">🎯 Objetivos</string>
+    <string name="onboarding_category_experience">⭐ Experiencia</string>
+    <string name="onboarding_category_preferences">❤️ Preferencias</string>
+    <string name="onboarding_category_personalization">✨ Personalización</string>
+    <string name="onboarding_category_information">ℹ️ Información</string>
     <string name="massage_zones_completed">Zonas completadas: %1$d/%2$d</string>
     <string name="massage_zone_previous">Zona anterior</string>
     <string name="massage_zone_next">Zona siguiente</string>
@@ -461,6 +468,11 @@
     <string name="common_next">Siguiente</string>
     <string name="common_finish">Terminar</string>
     <string name="common_ok">OK</string>
+    <string name="content_desc_previous">Anterior</string>
+    <string name="content_desc_next">Siguiente</string>
+    <string name="content_desc_complete">Completar</string>
+    <string name="content_desc_selected">Seleccionado</string>
+    <string name="content_desc_time">Tiempo</string>
     <string name="common_days_unit">días</string>
     <string name="common_select_date">Seleccionar una fecha</string>
     <string name="common_select">Seleccionar</string>
@@ -488,10 +500,6 @@
     <string name="onboarding_character_count">%1$d / %2$d caracteres</string>
     <string name="onboarding_error_load_config">No se puede cargar el cuestionario</string>
     <string name="onboarding_preparing">Preparando tu cuestionario...</string>
-    <string name="onboarding_category_goals">🎯 Objetivos</string>
-    <string name="onboarding_category_experience">⭐ Experiencia</string>
-    <string name="onboarding_category_preferences">❤️ Preferencias</string>
-    <string name="onboarding_category_personalization">✨ Personalización</string>
     <string name="onboarding_feature_personalized_title">Contenido personalizado</string>
     <string name="onboarding_feature_personalized_desc">Recomendaciones adaptadas a tus objetivos</string>
     <string name="onboarding_feature_tracking_title">Seguimiento de progreso</string>
@@ -505,6 +513,7 @@
     <string name="error_config_not_loaded">Configuración no cargada</string>
     <string name="error_load_questionnaire">No se puede cargar el cuestionario: %1$s</string>
     <string name="error_save_onboarding">Error al guardar: %1$s</string>
+    <string name="onboarding_error_load_config_with_reason">No se puede cargar el cuestionario: %1$s</string>
 
     <!-- Home Personalized Section -->
     <string name="home_personalized_description">Basado en tus objetivos y preferencias</string>

--- a/source/repos/Ora/app/src/main/res/values/strings.xml
+++ b/source/repos/Ora/app/src/main/res/values/strings.xml
@@ -253,6 +253,11 @@
     <string name="common_next">Suivant</string>
     <string name="common_finish">Terminer</string>
     <string name="common_ok">OK</string>
+    <string name="content_desc_previous">Précédent</string>
+    <string name="content_desc_next">Suivant</string>
+    <string name="content_desc_complete">Terminer</string>
+    <string name="content_desc_selected">Sélectionné</string>
+    <string name="content_desc_time">Temps</string>
     <string name="common_days_unit">jours</string>
     <string name="common_select_date">Sélectionner une date</string>
     <string name="common_select">Sélectionner</string>
@@ -291,10 +296,6 @@
     <string name="onboarding_character_count">%1$d / %2$d caractères</string>
     <string name="onboarding_error_load_config">Impossible de charger le questionnaire</string>
     <string name="onboarding_preparing">Préparation de votre questionnaire...</string>
-    <string name="onboarding_category_goals">🎯 Objectifs</string>
-    <string name="onboarding_category_experience">⭐ Expérience</string>
-    <string name="onboarding_category_preferences">❤️ Préférences</string>
-    <string name="onboarding_category_personalization">✨ Personnalisation</string>
 
     <!-- Accessibility -->
     <string name="accessibility_decrement">Décrémenter</string>
@@ -316,6 +317,7 @@
     <string name="error_config_not_loaded">Configuration non chargée</string>
     <string name="error_load_questionnaire">Impossible de charger le questionnaire : %1$s</string>
     <string name="error_save_onboarding">Erreur lors de la sauvegarde : %1$s</string>
+    <string name="onboarding_error_load_config_with_reason">Impossible de charger le questionnaire : %1$s</string>
 
     <!-- Auth (Issue #39 - Phase 1a) -->
     <string name="app_tagline">Body · Mind · Soul</string>
@@ -431,6 +433,13 @@
     <string name="massage_pressure_low">Légère</string>
     <string name="massage_pressure_medium">Moyenne</string>
     <string name="massage_pressure_high">Forte</string>
+
+    <!-- Onboarding Categories (NEW - Issue #39 - Phase 1d.2) -->
+    <string name="onboarding_category_goals">🎯 Objectifs</string>
+    <string name="onboarding_category_experience">⭐ Expérience</string>
+    <string name="onboarding_category_preferences">❤️ Préférences</string>
+    <string name="onboarding_category_personalization">✨ Personnalisation</string>
+    <string name="onboarding_category_information">ℹ️ Information</string>
     <string name="massage_zones_completed">Zones terminées : %1$d/%2$d</string>
     <string name="massage_zone_previous">Zone précédente</string>
     <string name="massage_zone_next">Zone suivante</string>


### PR DESCRIPTION
## Summary

This PR completes the internationalization of the onboarding flow with full support for **French**, **English**, and **Spanish** languages. It also merges the first two information screens into a single, clearer welcome screen with feature highlights.

## Problem Solved

- ✅ Profile field placeholders were showing in French instead of English/Spanish
- ✅ Category badges ("Personnalisation", "Expérience") were not translated
- ✅ Information screens 0 and 1 were redundant and confusing
- ✅ Spanish language support was incomplete

## Changes Made

### 🔧 Backend (Firestore)
- Merged information screens 0 and 1 into a single welcome screen
- New screen structure:
  - Title: "Bienvenue sur ORA" / "Welcome to ORA" / "Bienvenido a ORA"
  - Subtitle: "2 minutes pour personnaliser ton expérience..."
  - 3 Features with icons:
    - ✨ Questions simples et adaptées
    - ⏱️ Moins de 2 minutes
    - 🎯 Un parcours 100% personnalisé

### 📱 Android Models
- **New**: `InformationScreenFeature` class with full i18n support
- **Extended**: `ProfileField` with `placeholderFr/En/Es` fields
- **Extended**: `InformationScreen` and `QuestionTypeConfig` with `features` field
- **Methods**: Added `getLocalizedLabel()` and `getLocalizedPlaceholder()`

### 🎨 Android UI
- **ProfileGroupContent**: Uses localized labels and placeholders for all input types (TEXT, DATE, RADIO)
- **InformationScreenContent**: Displays features with emoji icons in card layout
- **getCategoryLabel()**: Added support for "information" category
- **Spanish support**: Added `contentEs` and `bulletPointsEs` handling

### 🌍 String Resources
- Added `onboarding_category_information` in FR/EN/ES
- Category translations: goals, experience, preferences, personalization
- All translations validated and tested

## UI Before/After

**Before** (2 screens):
```
Screen 1: "Bienvenue sur ORA"
  - Simple subtitle

Screen 2: "Construisons ton profil ORA"  
  - Another subtitle
```

**After** (1 merged screen):
```
"Bienvenue sur ORA"
  - Clear subtitle explaining the process
  
  ✨ Questions simples et adaptées
     Detailed description...
  
  ⏱️ Moins de 2 minutes
     Detailed description...
  
  🎯 Un parcours 100% personnalisé
     Detailed description...
```

## Test Plan

- [x] Build successful with no compilation errors
- [x] Verify placeholders show in correct language:
  - FR: "Prénom", "Date de naissance"
  - EN: "Your first name", "DD/MM/YYYY"
  - ES: "Tu nombre", "DD/MM/AAAA"
- [x] Verify category badges translate:
  - FR: "✨ Personnalisation"
  - EN: "✨ Personalization"
  - ES: "✨ Personalización"
- [x] Verify merged information screen displays features correctly

## Screenshots

_User provided screenshots showing the issues are now fixed_

## Related Issues

Closes part of #39 - Onboarding internationalization

## Checklist

- [x] Code follows project coding standards
- [x] All new strings added to FR/EN/ES resource files
- [x] No hardcoded user-facing strings
- [x] Build passes with no errors
- [x] Architecture consistent with existing i18n patterns (camelCase fields)
- [x] Firestore data updated with all translations

🤖 Generated with [Claude Code](https://claude.com/claude-code)