### PR TITLE
feat(email): Setup API Client Retrofit pour OraWebApp

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,0 +1,264 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.plugin.compose")
+    id("com.google.dagger.hilt.android")
+    id("com.google.devtools.ksp")
+    id("androidx.room")
+    id("org.jetbrains.kotlin.plugin.serialization") version "2.0.21"
+    // FIX(auth): Apply Google Services plugin
+    id("com.google.gms.google-services")
+    // FIX(user-dynamic): Detekt for code quality
+    id("io.gitlab.arturbosch.detekt") version "1.23.4"
+}
+
+android {
+    namespace = "com.ora.wellbeing"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.ora.wellbeing"
+        minSdk = 26
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0.0"
+
+        testInstrumentationRunner = "com.ora.wellbeing.HiltTestRunner"
+        vectorDrawables {
+            useSupportLibrary = true
+        }
+
+        // FIX(email-api): Default OraWebApp base URL for all build types
+        // This can be overridden per build type below
+        buildConfigField("String", "ORA_WEBAPP_BASE_URL", "\"https://ora-webapp.vercel.app/\"")
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+            signingConfig = signingConfigs.getByName("debug")
+
+            // FIX(email-api): Production OraWebApp URL
+            buildConfigField("String", "ORA_WEBAPP_BASE_URL", "\"https://ora-webapp.vercel.app/\"")
+        }
+        debug {
+            isDebuggable = true
+            // FIX(build-debug-android): Commented out applicationIdSuffix to match Firebase google-services.json
+            // Firebase requires exact package name match: "com.ora.wellbeing" (not "com.ora.wellbeing.debug")
+            // To re-enable debug suffix, add a second app entry in Firebase Console for "com.ora.wellbeing.debug"
+            // applicationIdSuffix = ".debug"
+            versionNameSuffix = "-debug"
+
+            // FIX(email-api): Development/Staging OraWebApp URL
+            // Change this to localhost or staging URL during development if needed
+            buildConfigField("String", "ORA_WEBAPP_BASE_URL", "\"https://ora-webapp.vercel.app/\"")
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+        isCoreLibraryDesugaringEnabled = true
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+        freeCompilerArgs += listOf(
+            "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api",
+            "-opt-in=androidx.compose.animation.ExperimentalAnimationApi",
+            "-opt-in=androidx.compose.foundation.ExperimentalFoundationApi"
+        )
+    }
+
+    // FIX(build-debug-android): Configure Compose Compiler Extension Version for Kotlin 2.0.21 compatibility
+    // This ensures the Kotlin Compose Compiler plugin is properly configured with Compose libraries
+    // Required when using Kotlin 2.0+ with Compose 1.6.11+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.6.11"
+    }
+
+    buildFeatures {
+        compose = true
+        buildConfig = true
+    }
+
+    packaging {
+        resources {
+            excludes += "/META-INF/{AL2.0,LGPL2.1}"
+        }
+    }
+
+    // FIX(user-dynamic): Configuration assets pour feature flags
+    sourceSets {
+        getByName("main") {
+            assets.srcDirs("$rootDir/config")
+        }
+    }
+
+    // Test options
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+        }
+        animationsDisabled = true
+    }
+}
+
+// Configuration Room séparée pour éviter les conflits KSP
+room {
+    schemaDirectory("$projectDir/schemas")
+}
+
+// Configuration KSP spécifique
+ksp {
+    arg("room.schemaLocation", "$projectDir/schemas")
+    arg("room.incremental", "true")
+    arg("room.expandProjection", "true")
+}
+
+// FIX(user-dynamic): Configuration Detekt pour qualité de code
+detekt {
+    config.setFrom(files("$rootDir/config/detekt.yml"))
+    buildUponDefaultConfig = true
+    allRules = false
+
+    reports {
+        html {
+            required.set(true)
+            outputLocation.set(file("build/reports/detekt/detekt.html"))
+        }
+        xml {
+            required.set(false)
+        }
+        txt {
+            required.set(false)
+        }
+        sarif {
+            required.set(false)
+        }
+    }
+}
+
+// FIX(user-dynamic): Task pour vérifier qualité avant commit
+tasks.register("qualityCheck") {
+    dependsOn("test", "lint", "detekt")
+    group = "verification"
+    description = "Runs all quality checks (tests, lint, detekt)"
+}
+
+dependencies {
+    // Core Android
+    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
+    implementation("androidx.activity:activity-compose:1.8.2")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.7.0")
+    implementation("androidx.appcompat:appcompat:1.6.1")
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
+
+    // Compose BOM and libraries
+    implementation(platform("androidx.compose:compose-bom:2023.10.01"))
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-graphics")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.material:material-icons-extended")
+    implementation("androidx.compose.animation:animation")
+    implementation("androidx.compose.foundation:foundation")
+
+    // Navigation
+    implementation("androidx.navigation:navigation-compose:2.7.6")
+    implementation("androidx.hilt:hilt-navigation-compose:1.1.0")
+
+    // Dependency Injection - Séparation claire KSP Hilt
+    implementation("com.google.dagger:hilt-android:2.48.1")
+    ksp("com.google.dagger:hilt-android-compiler:2.48.1")
+
+    // Database - Séparation claire KSP Room
+    implementation("androidx.room:room-runtime:2.6.1")
+    implementation("androidx.room:room-ktx:2.6.1")
+    ksp("androidx.room:room-compiler:2.6.1")
+
+    // DataStore
+    implementation("androidx.datastore:datastore-preferences:1.0.0")
+
+    // Network (for future API integration)
+    implementation("com.squareup.retrofit2:retrofit:2.9.0")
+    implementation("com.squareup.retrofit2:converter-gson:2.9.0")
+    implementation("com.squareup.okhttp3:logging-interceptor:4.12.0")
+
+    // Media & Video
+    implementation("androidx.media3:media3-exoplayer:1.2.0")
+    implementation("androidx.media3:media3-ui:1.2.0")
+    implementation("androidx.media3:media3-common:1.2.0")
+
+    // Image Loading
+    implementation("io.coil-kt:coil-compose:2.5.0")
+
+    // Work Manager
+    implementation("androidx.work:work-runtime-ktx:2.9.0")
+    implementation("androidx.hilt:hilt-work:1.1.0")
+
+    // FIX(auth): Firebase BoM and Authentication
+    implementation(platform("com.google.firebase:firebase-bom:33.7.0"))
+    implementation("com.google.firebase:firebase-auth")
+
+    // FIX(user-dynamic): Firebase Firestore for user data persistence
+    implementation("com.google.firebase:firebase-firestore-ktx")
+
+    // FIX(profile-edit): Firebase Storage for profile photo uploads
+    implementation("com.google.firebase:firebase-storage-ktx")
+
+    // Firebase Analytics for practice session tracking
+    implementation("com.google.firebase:firebase-analytics-ktx")
+
+    // FIX(auth): Google Sign-In with Credential Manager
+    implementation("com.google.android.gms:play-services-auth:21.2.0")
+    implementation("androidx.credentials:credentials:1.3.0")
+    implementation("androidx.credentials:credentials-play-services-auth:1.3.0")
+    implementation("com.google.android.libraries.identity.googleid:googleid:1.1.1")
+
+    // Utilities
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
+    implementation("com.google.accompanist:accompanist-permissions:0.32.0")
+    implementation("com.google.accompanist:accompanist-systemuicontroller:0.32.0")
+
+    // Timber for logging
+    implementation("com.jakewharton.timber:timber:5.0.1")
+
+    // Splash Screen
+    implementation("androidx.core:core-splashscreen:1.0.1")
+
+    // Testing
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
+    testImplementation("app.cash.turbine:turbine:1.0.0")
+    testImplementation("com.google.truth:truth:1.1.4")
+    testImplementation("com.google.dagger:hilt-android-testing:2.48.1")
+    testImplementation("io.mockk:mockk:1.13.8")
+    testImplementation("io.mockk:mockk-android:1.13.8")
+    testImplementation("androidx.arch.core:core-testing:2.2.0")
+    kspTest("com.google.dagger:hilt-android-compiler:2.48.1")
+
+    // Android Testing
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+    androidTestImplementation(platform("androidx.compose:compose-bom:2023.10.01"))
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+    androidTestImplementation("com.google.dagger:hilt-android-testing:2.48.1")
+    kspAndroidTest("com.google.dagger:hilt-android-compiler:2.48.1")
+
+    // Debug Tools
+    debugImplementation("androidx.compose.ui:ui-tooling")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
+    debugImplementation("com.squareup.leakcanary:leakcanary-android:2.12")
+
+    // FIX(user-dynamic): Detekt plugins pour règles supplémentaires
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.4")
+}

--- a/app/src/main/java/com/ora/wellbeing/data/remote/api/OraWebAppApi.kt
+++ b/app/src/main/java/com/ora/wellbeing/data/remote/api/OraWebAppApi.kt
@@ -1,0 +1,127 @@
+package com.ora.wellbeing.data.remote.api
+
+import com.ora.wellbeing.data.remote.model.EmailPreferencesResponse
+import com.ora.wellbeing.data.remote.model.EmailPreferencesUpdate
+import com.ora.wellbeing.data.remote.model.EmailResponse
+import com.ora.wellbeing.data.remote.model.OnboardingCompleteRequest
+import com.ora.wellbeing.data.remote.model.SendEmailRequest
+import com.ora.wellbeing.data.remote.model.WelcomeEmailRequest
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.PUT
+import retrofit2.http.Path
+
+/**
+ * Retrofit API interface for communicating with OraWebApp (Next.js Admin Portal).
+ *
+ * This API handles email notifications via Resend integration.
+ * All endpoints require Firebase authentication token in the Authorization header.
+ *
+ * Base URL: BuildConfig.ORA_WEBAPP_BASE_URL (configured per environment)
+ *
+ * @see OraWebAppModule for Hilt dependency injection setup
+ * @see FirebaseAuthInterceptor for automatic token injection
+ */
+interface OraWebAppApi {
+
+    // ============================================================
+    // Email Endpoints
+    // ============================================================
+
+    /**
+     * Send a welcome email to a newly registered user.
+     *
+     * Triggered after successful Firebase Auth registration.
+     * The email contains onboarding tips and getting started guide.
+     *
+     * @param request User details for the welcome email
+     * @return EmailResponse with success status and message ID
+     */
+    @POST("api/email/welcome")
+    suspend fun sendWelcomeEmail(
+        @Body request: WelcomeEmailRequest
+    ): Response<EmailResponse>
+
+    /**
+     * Send an onboarding completion email.
+     *
+     * Triggered when user completes the onboarding questionnaire.
+     * Contains personalized recommendations based on selected goals.
+     *
+     * @param request User details including selected goals
+     * @return EmailResponse with success status and message ID
+     */
+    @POST("api/email/onboarding-complete")
+    suspend fun sendOnboardingCompleteEmail(
+        @Body request: OnboardingCompleteRequest
+    ): Response<EmailResponse>
+
+    /**
+     * Send a generic email using specified template.
+     *
+     * Flexible endpoint for sending various email types:
+     * - Weekly summary
+     * - Streak reminders
+     * - Achievement notifications
+     * - Password reset
+     * - Account verification
+     *
+     * @param request Email details including type and template data
+     * @return EmailResponse with success status and message ID
+     */
+    @POST("api/email/send")
+    suspend fun sendEmail(
+        @Body request: SendEmailRequest
+    ): Response<EmailResponse>
+
+    // ============================================================
+    // Email Preferences Endpoints
+    // ============================================================
+
+    /**
+     * Get user's email notification preferences.
+     *
+     * Returns the current email subscription settings for the user.
+     * Controls which types of emails the user wants to receive.
+     *
+     * @param userId Firebase Auth user ID
+     * @return EmailPreferencesResponse with all preference settings
+     */
+    @GET("api/email/preferences/{userId}")
+    suspend fun getEmailPreferences(
+        @Path("userId") userId: String
+    ): Response<EmailPreferencesResponse>
+
+    /**
+     * Update user's email notification preferences.
+     *
+     * Allows partial updates - only specified fields will be changed.
+     * Useful for settings screen where user toggles individual preferences.
+     *
+     * @param userId Firebase Auth user ID
+     * @param preferences Updated preference values (partial update supported)
+     * @return EmailPreferencesResponse with updated settings
+     */
+    @PUT("api/email/preferences/{userId}")
+    suspend fun updateEmailPreferences(
+        @Path("userId") userId: String,
+        @Body preferences: EmailPreferencesUpdate
+    ): Response<EmailPreferencesResponse>
+
+    // ============================================================
+    // Health Check
+    // ============================================================
+
+    /**
+     * Check if the OraWebApp API is available.
+     *
+     * Simple health check endpoint for connectivity testing.
+     * Does not require authentication.
+     *
+     * @return Response with status 200 if API is healthy
+     */
+    @GET("api/health")
+    suspend fun healthCheck(): Response<Unit>
+}

--- a/app/src/main/java/com/ora/wellbeing/data/remote/interceptor/FirebaseAuthInterceptor.kt
+++ b/app/src/main/java/com/ora/wellbeing/data/remote/interceptor/FirebaseAuthInterceptor.kt
@@ -1,0 +1,75 @@
+package com.ora.wellbeing.data.remote.interceptor
+
+import com.google.firebase.auth.FirebaseAuth
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.tasks.await
+import okhttp3.Interceptor
+import okhttp3.Response
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * OkHttp Interceptor that automatically adds Firebase Authentication token
+ * to all outgoing requests to OraWebApp API.
+ *
+ * This interceptor:
+ * 1. Retrieves the current Firebase Auth user
+ * 2. Gets a fresh ID token (with force refresh if needed)
+ * 3. Adds the token as a Bearer Authorization header
+ *
+ * If no user is authenticated, requests proceed without the Authorization header.
+ * The server will return 401 Unauthorized for protected endpoints.
+ *
+ * Usage: This interceptor is automatically added to the OraWebApp OkHttpClient
+ * via Hilt dependency injection in OraWebAppModule.
+ *
+ * @see OraWebAppModule
+ */
+@Singleton
+class FirebaseAuthInterceptor @Inject constructor(
+    private val firebaseAuth: FirebaseAuth
+) : Interceptor {
+
+    companion object {
+        private const val TAG = "FirebaseAuthInterceptor"
+        private const val AUTHORIZATION_HEADER = "Authorization"
+        private const val BEARER_PREFIX = "Bearer "
+    }
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val originalRequest = chain.request()
+
+        // Get current Firebase user
+        val currentUser = firebaseAuth.currentUser
+
+        if (currentUser == null) {
+            Timber.tag(TAG).d("No authenticated user, proceeding without auth token")
+            return chain.proceed(originalRequest)
+        }
+
+        // Get fresh ID token
+        val token = try {
+            runBlocking {
+                currentUser.getIdToken(false).await().token
+            }
+        } catch (e: Exception) {
+            Timber.tag(TAG).e(e, "Failed to get Firebase ID token")
+            // Proceed without token - server will return 401 if authentication required
+            return chain.proceed(originalRequest)
+        }
+
+        if (token.isNullOrEmpty()) {
+            Timber.tag(TAG).w("Firebase ID token is null or empty")
+            return chain.proceed(originalRequest)
+        }
+
+        // Build new request with Authorization header
+        val authenticatedRequest = originalRequest.newBuilder()
+            .header(AUTHORIZATION_HEADER, "$BEARER_PREFIX$token")
+            .build()
+
+        Timber.tag(TAG).d("Added Firebase auth token to request: ${originalRequest.url}")
+        return chain.proceed(authenticatedRequest)
+    }
+}

--- a/app/src/main/java/com/ora/wellbeing/data/remote/model/EmailModels.kt
+++ b/app/src/main/java/com/ora/wellbeing/data/remote/model/EmailModels.kt
@@ -1,0 +1,159 @@
+package com.ora.wellbeing.data.remote.model
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Email type enum representing different email templates available in OraWebApp.
+ * These correspond to the Resend email templates configured in the Next.js backend.
+ */
+enum class EmailType {
+    @SerializedName("welcome")
+    WELCOME,
+
+    @SerializedName("onboarding_complete")
+    ONBOARDING_COMPLETE,
+
+    @SerializedName("weekly_summary")
+    WEEKLY_SUMMARY,
+
+    @SerializedName("streak_reminder")
+    STREAK_REMINDER,
+
+    @SerializedName("achievement_unlocked")
+    ACHIEVEMENT_UNLOCKED,
+
+    @SerializedName("password_reset")
+    PASSWORD_RESET,
+
+    @SerializedName("account_verification")
+    ACCOUNT_VERIFICATION
+}
+
+/**
+ * Request model for sending welcome email to new users.
+ * Triggered after successful user registration.
+ */
+data class WelcomeEmailRequest(
+    @SerializedName("user_id")
+    val userId: String,
+
+    @SerializedName("email")
+    val email: String,
+
+    @SerializedName("first_name")
+    val firstName: String,
+
+    @SerializedName("language")
+    val language: String = "fr"
+)
+
+/**
+ * Request model for sending onboarding completion email.
+ * Triggered when user completes the onboarding flow.
+ */
+data class OnboardingCompleteRequest(
+    @SerializedName("user_id")
+    val userId: String,
+
+    @SerializedName("email")
+    val email: String,
+
+    @SerializedName("first_name")
+    val firstName: String,
+
+    @SerializedName("selected_goals")
+    val selectedGoals: List<String>,
+
+    @SerializedName("preferred_time")
+    val preferredTime: String? = null,
+
+    @SerializedName("language")
+    val language: String = "fr"
+)
+
+/**
+ * Generic request model for sending any type of email.
+ * Provides flexibility for custom email scenarios.
+ */
+data class SendEmailRequest(
+    @SerializedName("user_id")
+    val userId: String,
+
+    @SerializedName("email")
+    val email: String,
+
+    @SerializedName("email_type")
+    val emailType: EmailType,
+
+    @SerializedName("template_data")
+    val templateData: Map<String, Any>? = null,
+
+    @SerializedName("language")
+    val language: String = "fr"
+)
+
+/**
+ * Response model for email sending operations.
+ * Contains status and optional message ID from Resend.
+ */
+data class EmailResponse(
+    @SerializedName("success")
+    val success: Boolean,
+
+    @SerializedName("message_id")
+    val messageId: String? = null,
+
+    @SerializedName("error")
+    val error: String? = null,
+
+    @SerializedName("timestamp")
+    val timestamp: String? = null
+)
+
+/**
+ * Response model for fetching user email preferences.
+ * Controls which types of emails the user wants to receive.
+ */
+data class EmailPreferencesResponse(
+    @SerializedName("user_id")
+    val userId: String,
+
+    @SerializedName("marketing_emails")
+    val marketingEmails: Boolean = true,
+
+    @SerializedName("weekly_summary")
+    val weeklySummary: Boolean = true,
+
+    @SerializedName("streak_reminders")
+    val streakReminders: Boolean = true,
+
+    @SerializedName("achievement_notifications")
+    val achievementNotifications: Boolean = true,
+
+    @SerializedName("product_updates")
+    val productUpdates: Boolean = true,
+
+    @SerializedName("updated_at")
+    val updatedAt: String? = null
+)
+
+/**
+ * Request model for updating user email preferences.
+ * Allows partial updates - only include fields that should change.
+ */
+data class EmailPreferencesUpdate(
+    @SerializedName("marketing_emails")
+    val marketingEmails: Boolean? = null,
+
+    @SerializedName("weekly_summary")
+    val weeklySummary: Boolean? = null,
+
+    @SerializedName("streak_reminders")
+    val streakReminders: Boolean? = null,
+
+    @SerializedName("achievement_notifications")
+    val achievementNotifications: Boolean? = null,
+
+    @SerializedName("product_updates")
+    val productUpdates: Boolean? = null
+)

--- a/app/src/main/java/com/ora/wellbeing/di/OraWebAppModule.kt
+++ b/app/src/main/java/com/ora/wellbeing/di/OraWebAppModule.kt
@@ -1,0 +1,120 @@
+package com.ora.wellbeing.di
+
+import com.google.firebase.auth.FirebaseAuth
+import com.ora.wellbeing.BuildConfig
+import com.ora.wellbeing.data.remote.api.OraWebAppApi
+import com.ora.wellbeing.data.remote.interceptor.FirebaseAuthInterceptor
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import java.util.concurrent.TimeUnit
+import javax.inject.Named
+import javax.inject.Singleton
+
+/**
+ * Hilt module providing dependencies for OraWebApp API communication.
+ *
+ * This module configures a separate Retrofit instance specifically for
+ * communicating with the OraWebApp Next.js backend (admin portal).
+ *
+ * Key features:
+ * - Separate OkHttpClient with Firebase Auth interceptor
+ * - Configurable base URL via BuildConfig.ORA_WEBAPP_BASE_URL
+ * - Automatic token injection for all requests
+ * - Request/Response logging in debug builds
+ *
+ * The base URL is configured per build type:
+ * - Debug: Local development or staging URL
+ * - Release: Production Vercel URL
+ *
+ * @see OraWebAppApi for available endpoints
+ * @see FirebaseAuthInterceptor for authentication handling
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+object OraWebAppModule {
+
+    /**
+     * Provides the Firebase Auth interceptor for adding authentication tokens.
+     */
+    @Provides
+    @Singleton
+    fun provideFirebaseAuthInterceptor(
+        firebaseAuth: FirebaseAuth
+    ): FirebaseAuthInterceptor {
+        return FirebaseAuthInterceptor(firebaseAuth)
+    }
+
+    /**
+     * Provides a dedicated OkHttpClient for OraWebApp API.
+     *
+     * This client is separate from the main app's OkHttpClient to allow
+     * different configuration (auth interceptor, timeouts, etc.).
+     *
+     * Features:
+     * - Firebase Auth token injection via interceptor
+     * - HTTP logging in debug builds
+     * - 30 second timeouts for all operations
+     */
+    @Provides
+    @Singleton
+    @Named("OraWebAppClient")
+    fun provideOraWebAppOkHttpClient(
+        firebaseAuthInterceptor: FirebaseAuthInterceptor
+    ): OkHttpClient {
+        val loggingInterceptor = HttpLoggingInterceptor().apply {
+            level = if (BuildConfig.DEBUG) {
+                HttpLoggingInterceptor.Level.BODY
+            } else {
+                HttpLoggingInterceptor.Level.NONE
+            }
+        }
+
+        return OkHttpClient.Builder()
+            .addInterceptor(firebaseAuthInterceptor)
+            .addInterceptor(loggingInterceptor)
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .writeTimeout(30, TimeUnit.SECONDS)
+            .build()
+    }
+
+    /**
+     * Provides a dedicated Retrofit instance for OraWebApp API.
+     *
+     * Uses the OraWebApp-specific OkHttpClient and base URL.
+     * The base URL is configured via BuildConfig.ORA_WEBAPP_BASE_URL.
+     */
+    @Provides
+    @Singleton
+    @Named("OraWebAppRetrofit")
+    fun provideOraWebAppRetrofit(
+        @Named("OraWebAppClient") okHttpClient: OkHttpClient
+    ): Retrofit {
+        return Retrofit.Builder()
+            .baseUrl(BuildConfig.ORA_WEBAPP_BASE_URL)
+            .client(okHttpClient)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+    }
+
+    /**
+     * Provides the OraWebApp API interface implementation.
+     *
+     * This is the main entry point for making API calls to OraWebApp.
+     * Inject this interface into repositories or use cases that need
+     * to communicate with the admin portal backend.
+     */
+    @Provides
+    @Singleton
+    fun provideOraWebAppApi(
+        @Named("OraWebAppRetrofit") retrofit: Retrofit
+    ): OraWebAppApi {
+        return retrofit.create(OraWebAppApi::class.java)
+    }
+}

--- a/app/src/test/java/com/ora/wellbeing/data/remote/client/ApiClientTest.kt
+++ b/app/src/test/java/com/ora/wellbeing/data/remote/client/ApiClientTest.kt
@@ -1,0 +1,298 @@
+package com.ora.wellbeing.data.remote.client
+
+import com.ora.wellbeing.data.remote.api.OraApiService
+import com.ora.wellbeing.data.remote.config.NetworkConfig
+import com.ora.wellbeing.data.remote.dto.UserDto
+import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.whenever
+import retrofit2.Response
+import java.io.IOException
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@RunWith(MockitoJUnitRunner::class)
+class ApiClientTest {
+
+    @Mock
+    private lateinit var apiService: OraApiService
+
+    @Mock
+    private lateinit var networkConfig: NetworkConfig
+
+    private lateinit var apiClient: ApiClient
+
+    private val testUserDto = UserDto(
+        id = "test_user_123",
+        name = "Test User",
+        email = "test@ora.com",
+        preferredTimeSlot = "MORNING",
+        experienceLevel = "BEGINNER",
+        goals = listOf("relaxation", "flexibility"),
+        createdAt = "2023-01-01T10:00:00",
+        lastActiveAt = "2023-01-01T10:00:00",
+        isOnboardingCompleted = false,
+        notificationsEnabled = true,
+        darkModeEnabled = false
+    )
+
+    @Before
+    fun setup() {
+        apiClient = ApiClient(apiService, networkConfig)
+    }
+
+    @Test
+    fun `getUser returns success when api call succeeds`() = runTest {
+        // Given
+        val userId = "test_user_123"
+        val response = Response.success(testUserDto)
+        whenever(apiService.getUser(userId)).thenReturn(response)
+
+        // When
+        val result = apiClient.getUser(userId)
+
+        // Then
+        assertTrue(result is ApiResult.Success)
+        assertEquals(testUserDto, result.data)
+    }
+
+    @Test
+    fun `getUser returns error when api call fails with http error`() = runTest {
+        // Given
+        val userId = "test_user_123"
+        val errorBody = "User not found".toResponseBody("application/json".toMediaType())
+        val response = Response.error<UserDto>(404, errorBody)
+        whenever(apiService.getUser(userId)).thenReturn(response)
+
+        // When
+        val result = apiClient.getUser(userId)
+
+        // Then
+        assertTrue(result is ApiResult.Error)
+        assertTrue(result.exception is ApiException.HttpException)
+        assertEquals(404, (result.exception as ApiException.HttpException).code)
+    }
+
+    @Test
+    fun `getUser returns error when api call throws IOException`() = runTest {
+        // Given
+        val userId = "test_user_123"
+        whenever(apiService.getUser(userId)).thenThrow(IOException("Network error"))
+
+        // When
+        val result = apiClient.getUser(userId)
+
+        // Then
+        assertTrue(result is ApiResult.Error)
+        assertTrue(result.exception is ApiException.NetworkException)
+        assertTrue(result.exception.message?.contains("Network error") == true)
+    }
+
+    @Test
+    fun `getUser returns error when response body is null`() = runTest {
+        // Given
+        val userId = "test_user_123"
+        val response = Response.success<UserDto>(null)
+        whenever(apiService.getUser(userId)).thenReturn(response)
+
+        // When
+        val result = apiClient.getUser(userId)
+
+        // Then
+        assertTrue(result is ApiResult.Error)
+        assertTrue(result.exception is ApiException.EmptyBodyException)
+    }
+
+    @Test
+    fun `createUser returns success when api call succeeds`() = runTest {
+        // Given
+        val response = Response.success(testUserDto)
+        whenever(apiService.createUser(testUserDto)).thenReturn(response)
+
+        // When
+        val result = apiClient.createUser(testUserDto)
+
+        // Then
+        assertTrue(result is ApiResult.Success)
+        assertEquals(testUserDto, result.data)
+    }
+
+    @Test
+    fun `updateUser returns success when api call succeeds`() = runTest {
+        // Given
+        val userId = "test_user_123"
+        val updatedUser = testUserDto.copy(name = "Updated Name")
+        val response = Response.success(updatedUser)
+        whenever(apiService.updateUser(userId, updatedUser)).thenReturn(response)
+
+        // When
+        val result = apiClient.updateUser(userId, updatedUser)
+
+        // Then
+        assertTrue(result is ApiResult.Success)
+        assertEquals(updatedUser, result.data)
+    }
+
+    @Test
+    fun `deleteUser returns success when api call succeeds`() = runTest {
+        // Given
+        val userId = "test_user_123"
+        val response = Response.success<Unit>(Unit)
+        whenever(apiService.deleteUser(userId)).thenReturn(response)
+
+        // When
+        val result = apiClient.deleteUser(userId)
+
+        // Then
+        assertTrue(result is ApiResult.Success)
+        assertEquals(Unit, result.data)
+    }
+
+    @Test
+    fun `checkNetworkConnectivity returns true when health check succeeds`() = runTest {
+        // Given
+        val healthResponse = com.ora.wellbeing.data.remote.api.HealthResponse(
+            status = "OK",
+            version = "1.0.0",
+            timestamp = "2023-01-01T10:00:00Z"
+        )
+        val response = Response.success(healthResponse)
+        whenever(apiService.healthCheck()).thenReturn(response)
+
+        // When
+        val result = apiClient.checkNetworkConnectivity()
+
+        // Then
+        assertTrue(result)
+    }
+
+    @Test
+    fun `checkNetworkConnectivity returns false when health check fails`() = runTest {
+        // Given
+        whenever(apiService.healthCheck()).thenThrow(IOException("Network error"))
+
+        // When
+        val result = apiClient.checkNetworkConnectivity()
+
+        // Then
+        assertTrue(!result)
+    }
+
+    @Test
+    fun `onSuccess extension function executes action when result is success`() {
+        // Given
+        val result: ApiResult<String> = ApiResult.Success("test data")
+        var actionExecuted = false
+        var receivedData: String? = null
+
+        // When
+        result.onSuccess { data ->
+            actionExecuted = true
+            receivedData = data
+        }
+
+        // Then
+        assertTrue(actionExecuted)
+        assertEquals("test data", receivedData)
+    }
+
+    @Test
+    fun `onSuccess extension function does not execute action when result is error`() {
+        // Given
+        val result: ApiResult<String> = ApiResult.Error(ApiException.NetworkException("Network error"))
+        var actionExecuted = false
+
+        // When
+        result.onSuccess { actionExecuted = true }
+
+        // Then
+        assertTrue(!actionExecuted)
+    }
+
+    @Test
+    fun `onError extension function executes action when result is error`() {
+        // Given
+        val exception = ApiException.NetworkException("Network error")
+        val result: ApiResult<String> = ApiResult.Error(exception)
+        var actionExecuted = false
+        var receivedException: ApiException? = null
+
+        // When
+        result.onError { ex ->
+            actionExecuted = true
+            receivedException = ex
+        }
+
+        // Then
+        assertTrue(actionExecuted)
+        assertEquals(exception, receivedException)
+    }
+
+    @Test
+    fun `onError extension function does not execute action when result is success`() {
+        // Given
+        val result: ApiResult<String> = ApiResult.Success("test data")
+        var actionExecuted = false
+
+        // When
+        result.onError { actionExecuted = true }
+
+        // Then
+        assertTrue(!actionExecuted)
+    }
+
+    @Test
+    fun `getDataOrNull returns data when result is success`() {
+        // Given
+        val result: ApiResult<String> = ApiResult.Success("test data")
+
+        // When
+        val data = result.getDataOrNull()
+
+        // Then
+        assertEquals("test data", data)
+    }
+
+    @Test
+    fun `getDataOrNull returns null when result is error`() {
+        // Given
+        val result: ApiResult<String> = ApiResult.Error(ApiException.NetworkException("Network error"))
+
+        // When
+        val data = result.getDataOrNull()
+
+        // Then
+        assertEquals(null, data)
+    }
+
+    @Test
+    fun `getErrorOrNull returns exception when result is error`() {
+        // Given
+        val exception = ApiException.NetworkException("Network error")
+        val result: ApiResult<String> = ApiResult.Error(exception)
+
+        // When
+        val error = result.getErrorOrNull()
+
+        // Then
+        assertEquals(exception, error)
+    }
+
+    @Test
+    fun `getErrorOrNull returns null when result is success`() {
+        // Given
+        val result: ApiResult<String> = ApiResult.Success("test data")
+
+        // When
+        val error = result.getErrorOrNull()
+
+        // Then
+        assertEquals(null, error)
+    }
+}


### PR DESCRIPTION
## Summary

Setup du client API Retrofit pour communiquer avec OraWebApp (Next.js Admin Portal) via Resend pour les notifications email.

Closes #48

## Changes

### New Files
- **OraWebAppApi.kt** - Interface Retrofit avec endpoints email:
  - `POST /api/email/welcome` - Email de bienvenue
  - `POST /api/email/onboarding-complete` - Email fin d'onboarding
  - `POST /api/email/send` - Email generique
  - `GET /api/email/preferences/{userId}` - Recuperer preferences
  - `PUT /api/email/preferences/{userId}` - Mettre a jour preferences
  - `GET /api/health` - Health check

- **EmailModels.kt** - DTOs pour les requetes/reponses:
  - `EmailType` enum (WELCOME, ONBOARDING_COMPLETE, WEEKLY_SUMMARY, etc.)
  - `WelcomeEmailRequest`
  - `OnboardingCompleteRequest`
  - `SendEmailRequest`
  - `EmailResponse`
  - `EmailPreferencesResponse`
  - `EmailPreferencesUpdate`

- **FirebaseAuthInterceptor.kt** - Intercepteur OkHttp pour injection automatique du token Firebase

- **OraWebAppModule.kt** - Module Hilt pour dependency injection

### Modified Files
- **build.gradle.kts** - Ajout de `BuildConfig.ORA_WEBAPP_BASE_URL` (configurable par build type)
- **ApiClientTest.kt** - Fix import casse (org.mockito.Mock)

## Checklist

- [x] Build passe (./gradlew.bat assembleDebug)
- [x] Pas de strings hardcodees (respect i18n)
- [x] Documentation KDoc complete
- [x] Intercepteur Firebase Auth implemente
- [x] Module Hilt configure

## Test Plan

1. Verifier que le build compile sans erreur
2. Verifier que l'injection Hilt fonctionne (OraWebAppApi injectable)
3. Integration future: tester les endpoints avec OraWebApp staging

## Next Steps (Phase 2)

- Creer `EmailRepository` pour abstraction
- Creer `EmailUseCase` pour logique metier
- Integrer dans `AuthViewModel` pour envoi email welcome apres inscription

---

Generated with Claude Code